### PR TITLE
Update elasticsearch service image in sample .magento.docker.yml

### DIFF
--- a/src/cloud/docker/docker-installation.md
+++ b/src/cloud/docker/docker-installation.md
@@ -78,7 +78,7 @@ To install an {{site.data.var.ee}} on-premises project:
            image: 'redis'
        elasticsearch:
            version: '7.5'
-           image: 'elasticsearch'
+           image: 'magento/magento-cloud-docker-elasticsearch'
    hooks:
        build: |
            set -e


### PR DESCRIPTION
## Purpose of this pull request

User will be able to generate correct `docker-compose.yml` file using the sample `.magento.docker.yml` in devdoc page. 
Currently we're having this issue:  [manifest for elasticsearch:7.5-1.3.0 not found](https://github.com/magento/magento-cloud-docker/issues/336) and [looks like the sample in devdoc is outdated](https://github.com/magento/magento-cloud-docker/issues/336#issuecomment-1093829082)

## Affected DevDocs pages

- [Prepare Commerce for Docker](https://devdocs.magento.com/cloud/docker/docker-installation.html)
